### PR TITLE
Add policy creation instructions

### DIFF
--- a/rest-to-websocket/FrontendApp.js
+++ b/rest-to-websocket/FrontendApp.js
@@ -33,7 +33,7 @@ class FrontendApp {
         const thingId = this.config.thingId;
         const connectionConfig = this.connectionConfigFunction();
 
-        this.baseUrl = `http://${connectionConfig.getHost()}/api/1/things/${thingId}`;
+        this.baseUrl = `http://${connectionConfig.getHost()}/api/2/things/${thingId}`; // updated from v1 to v2
 
         const basicAuth = btoa(`${connectionConfig.getUsername()}:${connectionConfig.getPassword()}`);
         $.ajaxSetup({

--- a/rest-to-websocket/README.md
+++ b/rest-to-websocket/README.md
@@ -42,6 +42,39 @@ All we need for this example is a running Eclipse Ditto instance.
 Please follow the guidelines at the [Eclipse Ditto](https://eclipse.dev/ditto/installation-running.html)
 project to get started.
 
+Additionally, you should create a policy `org.eclipse.ditto:smartcoffee`, example of creating a policy:
+```sh
+curl --request PUT \
+  --url http://localhost:8080/api/2/policies/org.eclipse.ditto:smartcoffee \
+  --header 'Content-Type: application/json' \
+  --header 'Authorization: Basic ZGl0dG86ZGl0dG8=' \
+  --data '{
+    "entries": {
+        "owner": {
+            "subjects": {
+                "nginx:ditto": {
+                    "type": "admin aissam"
+                }
+            },
+            "resources": {
+                "thing:/": {
+                    "grant": ["READ", "WRITE"],
+                    "revoke": []
+                },
+                "policy:/": {
+                    "grant": ["READ", "WRITE"],
+                    "revoke": []
+                },
+                "message:/": {
+                    "grant": ["READ", "WRITE"],
+                    "revoke": []
+                }
+            }
+        }
+    }
+}'
+```
+
 To use the UI, you can simply open `index.html` in your favorite (hopefully
  state-of-the-art :wink:) browser.
 

--- a/rest-to-websocket/README.md
+++ b/rest-to-websocket/README.md
@@ -42,7 +42,7 @@ All we need for this example is a running Eclipse Ditto instance.
 Please follow the guidelines at the [Eclipse Ditto](https://eclipse.dev/ditto/installation-running.html)
 project to get started.
 
-Additionally, you should create a policy `org.eclipse.ditto:smartcoffee`, example of creating a policy:
+Additionally, you should create the policy `org.eclipse.ditto:smartcoffee` (if it does not exist), example of creating a policy:
 ```sh
 curl --request PUT \
   --url http://localhost:8080/api/2/policies/org.eclipse.ditto:smartcoffee \

--- a/rest-to-websocket/SmartCoffeeApp.js
+++ b/rest-to-websocket/SmartCoffeeApp.js
@@ -312,7 +312,7 @@ class DittoWebSocket {
     }
 
     connect(connectionConfig, callback) {
-        const baseUrl = `ws://${connectionConfig.getUsername()}:${connectionConfig.getPassword()}@${connectionConfig.getHost()}/ws/1`;
+        const baseUrl = `ws://${connectionConfig.getUsername()}:${connectionConfig.getPassword()}@${connectionConfig.getHost()}/ws/2`; // updated from v1 to v2
         this.ws = new WebSocket(baseUrl);
         this.ws.onopen = () => this.onOpen(callback);
     }


### PR DESCRIPTION
If the policy is not created first, you will encounter a `Forbidden 403` error :
![image](https://github.com/eclipse-ditto/ditto-examples/assets/121689923/1fa20aef-7922-4c34-a78e-1c8bb390e12f)


```json
{
    "status": 403,
    "error": "things:thing.notmodifiable",
    "message": "The Thing with ID 'org.eclipse.ditto:smartcoffee' could not be accessed as its Policy with ID 'org.eclipse.ditto:smartcoffee' is not or no longer existing.",
    "description": "Recreate/create the Policy with ID 'org.eclipse.ditto:smartcoffee' in order to get access to the Thing again."
}
```
